### PR TITLE
[fix bug incude header]

### DIFF
--- a/sandbox/c++/cppshell/src/cppshell.cpp
+++ b/sandbox/c++/cppshell/src/cppshell.cpp
@@ -5,6 +5,7 @@
 #include <stack>
 #include <vector>
 
+#include <sys/wait.h>
 #include <unistd.h>
 
 


### PR DESCRIPTION
	To include <sys/wait> to prevent the compiler from complaining about
function wait(NULL).